### PR TITLE
Ensure class name case is consistent.

### DIFF
--- a/lib/Less/Functions.php
+++ b/lib/Less/Functions.php
@@ -999,7 +999,7 @@ class Less_Functions{
 			$returner = "'data:image/svg+xml,".$returner."'";
 		}
 
-		return new Less_Tree_URL( new Less_Tree_Anonymous( $returner ) );
+		return new Less_Tree_Url( new Less_Tree_Anonymous( $returner ) );
 	}
 
 

--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -104,7 +104,7 @@ class Less_Tree_Import extends Less_Tree{
 		if ($this->path instanceof Less_Tree_Quoted) {
 			$path = $this->path->value;
 			$path = ( isset($this->css) || preg_match('/(\.[a-z]*$)|([\?;].*)$/',$path)) ? $path : $path . '.less';
-		} else if ($this->path instanceof Less_Tree_URL) {
+		} else if ($this->path instanceof Less_Tree_Url) {
 			$path = $this->path->value->value;
 		}else{
 			return null;
@@ -126,7 +126,7 @@ class Less_Tree_Import extends Less_Tree{
 		}
 
 
-		if( !($path instanceof Less_Tree_URL) ){
+		if( !($path instanceof Less_Tree_Url) ){
 			if( $rootpath ){
 				$pathValue = $path->value;
 				// Add the base path if the import is relative

--- a/lib/Less/Tree/Url.php
+++ b/lib/Less/Tree/Url.php
@@ -70,7 +70,7 @@ class Less_Tree_Url extends Less_Tree{
 			}
 		}
 
-		return new Less_Tree_URL($val, $this->currentFileInfo, true);
+		return new Less_Tree_Url($val, $this->currentFileInfo, true);
 	}
 
 }


### PR DESCRIPTION
Try and make sure that class names are consistently cased, so as to not break autoloading on case-sensitive file systems.