### PR TITLE
Ensure rules isn't a required parameter otherwise this will break on PHP 8

### DIFF
--- a/lib/Less/Tree/Directive.php
+++ b/lib/Less/Tree/Directive.php
@@ -17,7 +17,7 @@ class Less_Tree_Directive extends Less_Tree{
 	public $debugInfo;
 	public $type = 'Directive';
 
-	public function __construct($name, $value = null, $rules, $index = null, $currentFileInfo = null, $debugInfo = null ){
+	public function __construct($name, $value = null, $rules = null, $index = null, $currentFileInfo = null, $debugInfo = null ){
 		$this->name = $name;
 		$this->value = $value;
 		if( $rules ){


### PR DESCRIPTION
`$rules` is a required parameter but `$value` is optional and comes before it. In PHP 8, this is deprecated.